### PR TITLE
Add more options to control what gets built

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -853,7 +853,7 @@ dependencies = [
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "oasis-rpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1998,7 +1998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+"checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ failure = "0.1"
 flate2 = "1.0"
 fs2 = "0.4"
 heck = "0.3"
-hex = "0.3"
+hex = "0.4"
 ignore = "0.4"
 log = "0.4"
 oasis-rpc = { version = "0.1", features = ["import"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,7 +31,10 @@ pub fn build_app<'a, 'b>() -> App<'a, 'b> {
             (@arg stack_size: +takes_value --stack-size
                 "Set the amount of linear memory allocated to program stack (in bytes)")
             (@arg wasi: --wasi "Build a vanilla WASI service")
-            (@arg SERVICE: +multiple "Specify which service(s) to build")
+            (@group artifacts =>
+                (@arg SERVICE: +multiple "Specify which service(s) to build")
+                (@arg only_services: --services "Build all services (and no apps)")
+            )
             (@arg builder_args: +raw "Args to pass to language-specific build tool")
         )
         (@subcommand test =>
@@ -41,7 +44,10 @@ pub fn build_app<'a, 'b>() -> App<'a, 'b> {
             (@arg debug: --debug "Build without optimizations")
             (@arg profile: -p --profile default_value[local]
                 "Set testing profile. Run `oasis config profile` \nto list available profiles.")
-            (@arg SERVICE: +multiple "Specify which service(s) to test")
+            (@group artifacts =>
+                (@arg SERVICE: +multiple "Specify which service(s) to build")
+                (@arg only_services: --services "Build all services (and no apps)")
+            )
             (@arg tester_args: +raw "Args to pass to language-specific test tool")
         )
         (@subcommand clean => (about: "Remove build products"))

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,13 +41,12 @@ macro_rules! profile_config_help {
     };
 }
 
+#[rustfmt::skip]
 macro_rules! default_config_toml {
     () => {
-        concat!(
-            r#"[profile.default]
-gateway = ""#,
-            default_gateway_url!(),
-            r#""
+        concat! {
+r#"[profile.default]
+gateway = ""#, default_gateway_url!(), r#""
 
 [profile.local]
 gateway = "ws://localhost:8546"  # web3
@@ -55,7 +54,7 @@ credential = "range drive remove bleak mule satisfy mandate east lion minimum un
 
 [telemetry]
 enabled = false"#
-        )
+        }
     };
 }
 

--- a/src/subcommands/clean.rs
+++ b/src/subcommands/clean.rs
@@ -1,11 +1,11 @@
 use crate::{
     command::{run_cmd, Verbosity},
     emit,
-    utils::{detect_projects, ProjectKind},
+    utils::{detect_projects, DevPhase, ProjectKind},
 };
 
 pub fn clean() -> Result<(), failure::Error> {
-    for proj in detect_projects()? {
+    for proj in detect_projects(DevPhase::Any)? {
         match proj.kind {
             ProjectKind::Rust(_) => {
                 emit!(cmd.clean, "rust");

--- a/src/subcommands/deploy.rs
+++ b/src/subcommands/deploy.rs
@@ -7,7 +7,7 @@ use crate::{
     config::{Config, DEFAULT_GATEWAY_URL},
     emit,
     error::{ProfileError, ProfileErrorKind},
-    utils::{detect_projects, print_status_in, ProjectKind, Status},
+    utils::{detect_projects, print_status_in, DevPhase, ProjectKind, Status},
 };
 
 macro_rules! print_need_deploy_key_message {
@@ -80,7 +80,7 @@ impl<'a> super::ExecSubcommand for DeployOptions<'a> {
 
 pub fn deploy(opts: DeployOptions) -> Result<(), failure::Error> {
     let mut found_deployable = false;
-    for proj in detect_projects()? {
+    for proj in detect_projects(DevPhase::Deploy)? {
         match proj.kind {
             ProjectKind::Rust(_) => (),
             ProjectKind::Javascript(manifest) => {


### PR DESCRIPTION
This PR allows you to specify `--services` to exclude building apps and also stops project detection from recursing into (lerna) meta-projects.

The motivation is the DS repo which contains js code that is not an app.

```diff
 oasis-build
 Build services for the Oasis platform

 USAGE:
     oasis build [FLAGS] [OPTIONS] [SERVICE]... [-- <builder_args>...]

 FLAGS:
         --debug       Build without optimizations
     -h, --help        Prints help information
+        --services    Build all services (and no apps)
     -q, --quiet       Decrease verbosity
     -V, --version     Prints version information
     -v, --verbose     Increase verbosity
         --wasi        Build a vanilla WASI service

 OPTIONS:
    -s, --stack <stack_size>    Set the amount of linear memory allocated to program stack (in bytes)

 ARGS:
     <SERVICE>...         Specify which service(s) to build
     <builder_args>...    Args to pass to language-specific build tool
```