### PR TITLE
Git version SHA: fall back to reading from file

### DIFF
--- a/src/subcommands/build.rs
+++ b/src/subcommands/build.rs
@@ -222,7 +222,7 @@ pub fn prep_wasm(input_wasm: &Path, output_wasm: &Path, debug: bool) -> Result<(
     // Add a section with version info for current git repo.
     let git_sha = match Command::new("git").args(&["rev-parse", "HEAD"]).output() {
         Ok(output) => strip_trailing_newline(output.stdout),
-        Err(_) => b"(git rev-parse failed)".to_vec(),
+        Err(_) => fs::read(".git/refs/heads/master").unwrap_or(b"(git rev-parse failed)".to_vec()),
     };
     let git_has_dirty_index = Command::new("git")
         .args(&["status", "--porcelain"])

--- a/src/subcommands/build.rs
+++ b/src/subcommands/build.rs
@@ -222,8 +222,9 @@ pub fn prep_wasm(input_wasm: &Path, output_wasm: &Path, debug: bool) -> Result<(
     // Add a section with version info for current git repo.
     let git_sha = match Command::new("git").args(&["rev-parse", "HEAD"]).output() {
         Ok(output) => strip_trailing_newline(output.stdout),
-        Err(_) => fs::read(".git/refs/heads/master")
-            .unwrap_or_else(|_| b"(git rev-parse failed)".to_vec()),
+        Err(_) => {
+            fs::read(".git_version_sha").unwrap_or_else(|_| b"(git rev-parse failed)".to_vec())
+        }
     };
     let git_has_dirty_index = Command::new("git")
         .args(&["status", "--porcelain"])

--- a/src/subcommands/build.rs
+++ b/src/subcommands/build.rs
@@ -222,7 +222,8 @@ pub fn prep_wasm(input_wasm: &Path, output_wasm: &Path, debug: bool) -> Result<(
     // Add a section with version info for current git repo.
     let git_sha = match Command::new("git").args(&["rev-parse", "HEAD"]).output() {
         Ok(output) => strip_trailing_newline(output.stdout),
-        Err(_) => fs::read(".git/refs/heads/master").unwrap_or(b"(git rev-parse failed)".to_vec()),
+        Err(_) => fs::read(".git/refs/heads/master")
+            .unwrap_or_else(|_| b"(git rev-parse failed)".to_vec()),
     };
     let git_has_dirty_index = Command::new("git")
         .args(&["status", "--porcelain"])


### PR DESCRIPTION
When building the services for our docker image (https://github.com/oasislabs/private-parcel/pull/1220/commits/2b88246540d4d0600e5bd933983667005bba645f), the .git dir is not available. It is too costly to copy the whole .git dir into docker scope, as it breaks docker's caching. But we can copy just the master ref, and pick it up with the addition from this PR.